### PR TITLE
cql3: values: make raw_value fragmented

### DIFF
--- a/atomic_cell.cc
+++ b/atomic_cell.cc
@@ -36,6 +36,10 @@ atomic_cell atomic_cell::make_live(const abstract_type& type, api::timestamp_typ
     return atomic_cell_type::make_live(timestamp, fragment_range(value));
 }
 
+atomic_cell atomic_cell::make_live(const abstract_type& type, api::timestamp_type timestamp, const cql3::raw_value_view::view& value, atomic_cell::collection_member cm) {
+    return atomic_cell_type::make_live(timestamp, fragment_range(value));
+}
+
 atomic_cell atomic_cell::make_live(const abstract_type& type, api::timestamp_type timestamp, ser::buffer_view<bytes_ostream::fragment_iterator> value, atomic_cell::collection_member cm) {
     return atomic_cell_type::make_live(timestamp, value);
 }
@@ -51,6 +55,11 @@ atomic_cell atomic_cell::make_live(const abstract_type& type, api::timestamp_typ
 }
 
 atomic_cell atomic_cell::make_live(const abstract_type& type, api::timestamp_type timestamp, managed_bytes_view value,
+                             gc_clock::time_point expiry, gc_clock::duration ttl, atomic_cell::collection_member cm) {
+    return atomic_cell_type::make_live(timestamp, fragment_range(value), expiry, ttl);
+}
+
+atomic_cell atomic_cell::make_live(const abstract_type& type, api::timestamp_type timestamp, const cql3::raw_value_view::view& value,
                              gc_clock::time_point expiry, gc_clock::duration ttl, atomic_cell::collection_member cm) {
     return atomic_cell_type::make_live(timestamp, fragment_range(value), expiry, ttl);
 }

--- a/atomic_cell.hh
+++ b/atomic_cell.hh
@@ -35,6 +35,7 @@
 #include "utils/fragmented_temporary_buffer.hh"
 
 #include "serializer.hh"
+#include "cql3/values.hh"
 
 class abstract_type;
 class collection_type_impl;
@@ -355,6 +356,8 @@ public:
                                  collection_member = collection_member::no);
     static atomic_cell make_live(const abstract_type& type, api::timestamp_type timestamp, const fragmented_temporary_buffer::view& value,
                                  collection_member = collection_member::no);
+    static atomic_cell make_live(const abstract_type& type, api::timestamp_type timestamp, const cql3::raw_value_view::view& value,
+                                 collection_member = collection_member::no);
     static atomic_cell make_live(const abstract_type& type, api::timestamp_type timestamp, const bytes& value,
                                  collection_member cm = collection_member::no) {
         return make_live(type, timestamp, bytes_view(value), cm);
@@ -367,6 +370,8 @@ public:
     static atomic_cell make_live(const abstract_type&, api::timestamp_type timestamp, ser::buffer_view<bytes_ostream::fragment_iterator> value,
         gc_clock::time_point expiry, gc_clock::duration ttl, collection_member = collection_member::no);
     static atomic_cell make_live(const abstract_type&, api::timestamp_type timestamp, const fragmented_temporary_buffer::view& value,
+        gc_clock::time_point expiry, gc_clock::duration ttl, collection_member = collection_member::no);
+    static atomic_cell make_live(const abstract_type&, api::timestamp_type timestamp, const cql3::raw_value_view::view& value,
         gc_clock::time_point expiry, gc_clock::duration ttl, collection_member = collection_member::no);
     static atomic_cell make_live(const abstract_type& type, api::timestamp_type timestamp, const bytes& value,
                                  gc_clock::time_point expiry, gc_clock::duration ttl, collection_member cm = collection_member::no)

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -73,7 +73,7 @@ public:
         value(cql3::raw_value bytes_) : _bytes(std::move(bytes_)) {}
         virtual cql3::raw_value get(const query_options& options) override { return _bytes; }
         virtual cql3::raw_value_view bind_and_get(const query_options& options) override { return _bytes.to_view(); }
-        virtual sstring to_string() const override { return to_hex(*_bytes); }
+        virtual sstring to_string() const override { return to_hex(to_bytes(_bytes.to_view())); }
     };
 
     static thread_local const ::shared_ptr<value> UNSET_VALUE;

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -124,7 +124,7 @@ lists::literal::to_string() const {
 }
 
 lists::value
-lists::value::from_serialized(const fragmented_temporary_buffer::view& val, const list_type_impl& type, cql_serialization_format sf) {
+lists::value::from_serialized(const cql3::raw_value_view::view& val, const list_type_impl& type, cql_serialization_format sf) {
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but compose does the validation (so we're fine).
@@ -520,7 +520,7 @@ lists::discarder_by_index::execute(mutation& m, const clustering_key_prefix& pre
     assert(cvalue);
 
     auto&& existing_list_opt = params.get_prefetched_list(m.key(), prefix, column);
-    int32_t idx = read_simple_exactly<int32_t>(*cvalue->_bytes);
+    int32_t idx = read_simple_exactly<int32_t>(*cvalue->_bytes.to_view());
     if (!existing_list_opt) {
         throw exceptions::invalid_request_exception("Attempted to delete an element from a list which is null");
     }

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -78,7 +78,7 @@ public:
         explicit value(std::vector<bytes_opt> elements)
             : _elements(std::move(elements)) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& v, const list_type_impl& type, cql_serialization_format sf);
+        static value from_serialized(const cql3::raw_value_view::view& v, const list_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const list_type_impl& lt, const value& v);

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -155,7 +155,7 @@ maps::literal::to_string() const {
 }
 
 maps::value
-maps::value::from_serialized(const fragmented_temporary_buffer::view& fragmented_value, const map_type_impl& type, cql_serialization_format sf) {
+maps::value::from_serialized(const cql3::raw_value_view::view& fragmented_value, const map_type_impl& type, cql_serialization_format sf) {
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but compose does the validation (so we're fine).
@@ -373,7 +373,7 @@ maps::discarder_by_key::execute(mutation& m, const clustering_key_prefix& prefix
         throw exceptions::invalid_request_exception("Invalid unset map key");
     }
     collection_mutation_description mut;
-    mut.cells.emplace_back(*key->get(params._options), params.make_dead_cell());
+    mut.cells.emplace_back(to_bytes(key->get(params._options)), params.make_dead_cell());
 
     m.set_cell(prefix, column, mut.serialize(*column.type));
 }

--- a/cql3/maps.hh
+++ b/cql3/maps.hh
@@ -81,7 +81,7 @@ public:
         value(std::map<bytes, bytes, serialized_compare> map)
             : map(std::move(map)) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& value, const map_type_impl& type, cql_serialization_format sf);
+        static value from_serialized(const cql3::raw_value_view::view& value, const map_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf);
         bool equals(const map_type_impl& mt, const value& v);

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -99,6 +99,10 @@ public:
         return params.make_cell(type, value);
     }
 
+    static atomic_cell make_cell(const abstract_type& type, const cql3::raw_value_view::view& value, const update_parameters& params) {
+        return params.make_cell(type, value);
+    }
+
     static atomic_cell make_counter_update_cell(int64_t delta, const update_parameters& params) {
         return params.make_counter_update_cell(delta);
     }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -133,7 +133,7 @@ sets::literal::to_string() const {
 }
 
 sets::value
-sets::value::from_serialized(const fragmented_temporary_buffer::view& val, const set_type_impl& type, cql_serialization_format sf) {
+sets::value::from_serialized(const cql3::raw_value_view::view& val, const set_type_impl& type, cql_serialization_format sf) {
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but compose does the validation (so we're fine).
@@ -339,7 +339,7 @@ void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& 
         throw exceptions::invalid_request_exception("Invalid null set element");
     }
     collection_mutation_description mut;
-    mut.cells.emplace_back(*elt->get(params._options), params.make_dead_cell());
+    mut.cells.emplace_back(to_bytes(elt->get(params._options)), params.make_dead_cell());
     m.set_cell(row_key, column, mut.serialize(*column.type));
 }
 

--- a/cql3/sets.hh
+++ b/cql3/sets.hh
@@ -78,7 +78,7 @@ public:
         value(std::set<bytes, serialized_compare> elements)
                 : _elements(std::move(elements)) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& v, const set_type_impl& type, cql_serialization_format sf);
+        static value from_serialized(const cql3::raw_value_view::view& v, const set_type_impl& type, cql_serialization_format sf);
         virtual cql3::raw_value get(const query_options& options) override;
         virtual bytes get_with_protocol_version(cql_serialization_format sf) override;
         bool equals(const set_type_impl& st, const value& v);

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -179,9 +179,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
 }
 
 modification_statement::json_cache_opt insert_prepared_json_statement::maybe_prepare_json_cache(const query_options& options) const {
-    sstring json_string = with_linearized(_term->bind_and_get(options).data().value(), [&] (bytes_view value) {
-        return utf8_type->to_string(bytes(value));
-    });
+    sstring json_string = utf8_type->to_string(to_bytes(_term->bind_and_get(options)));
     return json_helpers::parse(std::move(json_string), s->all_columns(), options.get_cql_serialization_format());
 }
 
@@ -217,19 +215,18 @@ insert_prepared_json_statement::execute_set_value(mutation& m, const clustering_
     visit(*column.type, make_visitor(
     [&] (const list_type_impl& ltype) {
         lists::setter::execute(m, prefix, params, column,
-                ::make_shared<lists::value>(lists::value::from_serialized(fragmented_temporary_buffer::view(*value), ltype, sf)));
+                ::make_shared<lists::value>(lists::value::from_serialized(cql3::raw_value_view::view(managed_bytes_view(*value)), ltype, sf)));
     },
     [&] (const set_type_impl& stype) {
         sets::setter::execute(m, prefix, params, column,
-                ::make_shared<sets::value>(sets::value::from_serialized(fragmented_temporary_buffer::view(*value), stype, sf)));
-    },
+                ::make_shared<sets::value>(sets::value::from_serialized(cql3::raw_value_view::view(managed_bytes_view(*value)), stype, sf))); },
     [&] (const map_type_impl& mtype) {
         maps::setter::execute(m, prefix, params, column,
-                ::make_shared<maps::value>(maps::value::from_serialized(fragmented_temporary_buffer::view(*value), mtype, sf)));
+                ::make_shared<maps::value>(maps::value::from_serialized(cql3::raw_value_view::view(managed_bytes_view(*value)), mtype, sf)));
     },
     [&] (const user_type_impl& utype) {
         user_types::setter::execute(m, prefix, params, column,
-                ::make_shared<user_types::value>(user_types::value::from_serialized(fragmented_temporary_buffer::view(*value), utype)));
+                ::make_shared<user_types::value>(user_types::value::from_serialized(cql3::raw_value_view::view(managed_bytes_view(*value)), utype)));
     },
     [&] (const abstract_type& type) {
         if (type.is_collection()) {

--- a/cql3/tuples.cc
+++ b/cql3/tuples.cc
@@ -81,7 +81,7 @@ tuples::literal::prepare(database& db, const sstring& keyspace, const std::vecto
 }
 
 tuples::in_value
-tuples::in_value::from_serialized(const fragmented_temporary_buffer::view& value_view, const list_type_impl& type, const query_options& options) {
+tuples::in_value::from_serialized(const cql3::raw_value_view::view& value_view, const list_type_impl& type, const query_options& options) {
     try {
         // Collections have this small hack that validate cannot be called on a serialized object,
         // but the deserialization does the validation (so we're fine).

--- a/cql3/tuples.hh
+++ b/cql3/tuples.hh
@@ -116,7 +116,7 @@ public:
         value(std::vector<bytes_view_opt> elements)
             : value(to_bytes_opt_vec(std::move(elements))) {
         }
-        static value from_serialized(const fragmented_temporary_buffer::view& buffer, const tuple_type_impl& type) {
+        static value from_serialized(const cql3::raw_value_view::view& buffer, const tuple_type_impl& type) {
           return with_linearized(buffer, [&] (bytes_view view) {
               return value(type.split(view));
           });
@@ -213,7 +213,7 @@ public:
             }
         }
 
-        static in_value from_serialized(const fragmented_temporary_buffer::view& value_view, const list_type_impl& type, const query_options& options);
+        static in_value from_serialized(const cql3::raw_value_view::view& value_view, const list_type_impl& type, const query_options& options);
 
         virtual cql3::raw_value get(const query_options& options) override {
             throw exceptions::unsupported_operation_exception();

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -171,6 +171,20 @@ public:
         }
     };
 
+    atomic_cell make_cell(const abstract_type& type, const cql3::raw_value_view::view& value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
+        auto ttl = _ttl;
+
+        if (ttl.count() <= 0) {
+            ttl = _schema->default_time_to_live();
+        }
+
+        if (ttl.count() > 0) {
+            return atomic_cell::make_live(type, _timestamp, value, _local_deletion_time + ttl, ttl, cm);
+        } else {
+            return atomic_cell::make_live(type, _timestamp, value, cm);
+        }
+    };
+
     atomic_cell make_cell(const abstract_type& type, bytes_view value, atomic_cell::collection_member cm = atomic_cell::collection_member::no) const {
         return make_cell(type, fragmented_temporary_buffer::view(value), cm);
     }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -154,7 +154,7 @@ user_types::value::value(std::vector<bytes_view_opt> elements)
     : value(to_bytes_opt_vec(std::move(elements))) {
 }
 
-user_types::value user_types::value::from_serialized(const fragmented_temporary_buffer::view& v, const user_type_impl& type) {
+user_types::value user_types::value::from_serialized(const cql3::raw_value_view::view& v, const user_type_impl& type) {
     return with_linearized(v, [&] (bytes_view val) {
         auto elements = type.split(val);
         if (elements.size() > type.size()) {
@@ -288,7 +288,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
         m.set_cell(row_key, column, mut.serialize(type));
     } else {
         if (value) {
-            m.set_cell(row_key, column, make_cell(type, *value->get(params._options), params));
+            m.set_cell(row_key, column, make_cell(type, *value->get(params._options).to_view(), params));
         } else {
             m.set_cell(row_key, column, make_dead_cell(params));
         }

--- a/cql3/user_types.hh
+++ b/cql3/user_types.hh
@@ -78,7 +78,7 @@ public:
         explicit value(std::vector<bytes_opt>);
         explicit value(std::vector<bytes_view_opt>);
 
-        static value from_serialized(const fragmented_temporary_buffer::view&, const user_type_impl&);
+        static value from_serialized(const cql3::raw_value_view::view&, const user_type_impl&);
 
         virtual cql3::raw_value get(const query_options&) override;
         virtual const std::vector<bytes_opt>& get_elements() const override;

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "types.hh"
 #include "bytes.hh"
 
 #include <optional>
@@ -30,95 +29,14 @@
 #include <seastar/util/variant_utils.hh>
 
 #include "utils/fragmented_temporary_buffer.hh"
+#include "utils/managed_bytes.hh"
 
 namespace cql3 {
 
-struct null_value {
-};
+class null_value {};
+class unset_value {};
 
-struct unset_value {
-};
-
-class raw_value;
-/// \brief View to a raw CQL protocol value.
-///
-/// \see raw_value
-struct raw_value_view {
-    std::variant<fragmented_temporary_buffer::view, null_value, unset_value> _data;
-    // Temporary storage is only useful if a raw_value_view needs to be instantiated
-    // with a value which lifetime is bounded only to the view itself.
-    // This hack is introduced in order to avoid storing temporary storage
-    // in an external container, which may cause memory leaking problems.
-    // This pointer is disengaged for regular raw_value_view instances.
-    // Data is stored in a shared pointer for two reasons:
-    // - pointers are cheap to copy
-    // - it makes the view keep its semantics - it's safe to copy a view multiple times
-    //   and all copies still refer to the same underlying data.
-    lw_shared_ptr<bytes> _temporary_storage = nullptr;
-
-    raw_value_view(null_value&& data)
-        : _data{std::move(data)}
-    {}
-    raw_value_view(unset_value&& data)
-        : _data{std::move(data)}
-    {}
-    raw_value_view(fragmented_temporary_buffer::view data)
-        : _data{data}
-    {}
-    // This constructor is only used by make_temporary() and it acquires ownership
-    // of the given buffer. The view created that way refers to its own temporary storage.
-    explicit raw_value_view(bytes&& temporary_storage);
-public:
-    static raw_value_view make_null() {
-        return raw_value_view{std::move(null_value{})};
-    }
-    static raw_value_view make_unset_value() {
-        return raw_value_view{std::move(unset_value{})};
-    }
-    static raw_value_view make_value(fragmented_temporary_buffer::view view) {
-        return raw_value_view{view};
-    }
-    static raw_value_view make_temporary(raw_value&& value);
-    bool is_null() const {
-        return std::holds_alternative<null_value>(_data);
-    }
-    bool is_unset_value() const {
-        return std::holds_alternative<unset_value>(_data);
-    }
-    bool is_value() const {
-        return std::holds_alternative<fragmented_temporary_buffer::view>(_data);
-    }
-    std::optional<fragmented_temporary_buffer::view> data() const {
-        if (auto pdata = std::get_if<fragmented_temporary_buffer::view>(&_data)) {
-            return *pdata;
-        }
-        return {};
-    }
-    explicit operator bool() const {
-        return is_value();
-    }
-    const fragmented_temporary_buffer::view* operator->() const {
-        return &std::get<fragmented_temporary_buffer::view>(_data);
-    }
-    const fragmented_temporary_buffer::view& operator*() const {
-        return std::get<fragmented_temporary_buffer::view>(_data);
-    }
-
-    bool operator==(const raw_value_view& other) const {
-        if (_data.index() != other._data.index()) {
-            return false;
-        }
-        if (is_value() && **this != *other) {
-            return false;
-        }
-        return true;
-    }
-    bool operator!=(const raw_value_view& other) const {
-        return !(*this == other);
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, const raw_value_view& value);
-};
+class raw_value_view;
 
 /// \brief Raw CQL protocol value.
 ///
@@ -126,37 +44,51 @@ public:
 /// protocol. A raw value can hold either a null value, an unset value, or a byte
 /// blob that represents the value.
 class raw_value {
-    std::variant<bytes, null_value, unset_value> _data;
+    std::variant<managed_bytes, bytes, null_value, unset_value> _data;
 
-    raw_value(null_value&& data)
-        : _data{std::move(data)}
+    raw_value(null_value data)
+        : _data{data}
     {}
-    raw_value(unset_value&& data)
-        : _data{std::move(data)}
+    raw_value(unset_value data)
+        : _data{data}
     {}
     raw_value(bytes&& data)
         : _data{std::move(data)}
     {}
-    raw_value(const bytes& data)
-        : _data{data}
+    raw_value(managed_bytes&& data)
+        : _data{std::move(data)}
     {}
 public:
     static raw_value make_null() {
-        return raw_value{std::move(null_value{})};
+        return raw_value{null_value{}};
     }
     static raw_value make_unset_value() {
-        return raw_value{std::move(unset_value{})};
+        return raw_value{unset_value{}};
     }
+#if 0
     static raw_value make_value(const raw_value_view& view);
-    static raw_value make_value(bytes&& bytes) {
-        return raw_value{std::move(bytes)};
+#endif
+    static raw_value make_value(managed_bytes&& b) {
+        return raw_value{std::move(b)};
     }
-    static raw_value make_value(const bytes& bytes) {
-        return raw_value{bytes};
+    static raw_value make_value(const managed_bytes& b) {
+        return raw_value{managed_bytes(b)};
     }
-    static raw_value make_value(const bytes_opt& bytes) {
-        if (bytes) {
-            return make_value(*bytes);
+    static raw_value make_value(const std::optional<managed_bytes>& b) {
+        if (b) {
+            return make_value(*b);
+        }
+        return make_null();
+    }
+    static raw_value make_value(bytes&& b) {
+        return raw_value{std::move(b)};
+    }
+    static raw_value make_value(const bytes& b) {
+        return raw_value{bytes(b)};
+    }
+    static raw_value make_value(const bytes_opt& b) {
+        if (b) {
+            return make_value(*b);
         }
         return make_null();
     }
@@ -167,31 +99,172 @@ public:
         return std::holds_alternative<unset_value>(_data);
     }
     bool is_value() const {
-        return std::holds_alternative<bytes>(_data);
-    }
-    bytes_opt data() const {
-        if (auto pdata = std::get_if<bytes>(&_data)) {
-            return *pdata;
-        }
-        return {};
+        return _data.index() <= 1;
     }
     explicit operator bool() const {
         return is_value();
     }
-    const bytes* operator->() const {
-        return &std::get<bytes>(_data);
-    }
-    const bytes& operator*() const {
-        return std::get<bytes>(_data);
-    }
-    bytes&& extract_value() && {
-        auto b = std::get_if<bytes>(&_data);
-        assert(b);
-        return std::move(*b);
-    }
     raw_value_view to_view() const;
+    bytes to_bytes() const {
+        if (auto p = std::get_if<bytes>(&_data)) {
+            return *p;
+        } else {
+            return ::to_bytes(std::get<managed_bytes>(_data));
+        }
+    }
+    friend class raw_value_view;
 };
 
+/// \brief View to a raw CQL protocol value.
+///
+/// \see raw_value
+class raw_value_view {
+public:
+    class view {
+    public:
+        using fragment_type = managed_bytes_view::fragment_type;
+    private:
+        // We use managed_bytes as a general-purpose fragmented buffer,
+        // so we want raw_value_view to handle managed_bytes_view,
+        // but we also want raw_value_view to handle fragmented_temporary_buffer::view without copying,
+        // because that's what's coming from the wire. Therefore, raw_value_view is a
+        // variant of managed_bytes_view and fragmented_temporary_buffer::view.
+        //
+        // Since the only part that differs between fragmented_temporary_buffer::view
+        // and managed_bytes_view is the method of getting the next fragment, which happens rarely,
+        // and the frequently used parts (accessing the first fragment and the total size)
+        // are common for both view types, we don't use a std::variant, and instead we store the
+        // common parts directly in raw_value_view, and only dispatch the action of getting the next
+        // fragment to the actual view type.
+        
+        using mb = managed_bytes_view::next_fragments_opaque;
+        using ftbv = fragmented_temporary_buffer::view::next_fragments_opaque;
+
+        std::variant<mb, ftbv, null_value, unset_value> _content;
+        fragment_type _current_fragment;
+        size_t _size = 0;
+
+        view(null_value data) : _content(data) {}
+        view(unset_value data) : _content(data) {}
+        view(const fragmented_temporary_buffer::view& data)
+            : _content(data.next_fragments())
+            , _current_fragment{data.current_fragment()}
+            , _size{data.size_bytes()}
+        {}
+
+    public:
+        view(const managed_bytes_view& data)
+            : _content(data.next_fragments())
+            , _current_fragment{data.current_fragment()}
+            , _size{data.size_bytes()}
+        {}
+
+        view() : view(unset_value()) {}
+
+        // Implements FragmentedView
+        size_t size_bytes() const { return _size; }
+        fragment_type current_fragment() const { return _current_fragment; }
+        bool empty() const { return _size == 0; }
+        void remove_prefix(size_t n) noexcept {
+            while (n >= _current_fragment.size() && n > 0) [[unlikely]] {
+                n -= _current_fragment.size();
+                remove_current();
+            }
+            _size -= n;
+            _current_fragment.remove_prefix(n);
+        }
+        void remove_current() {
+            _size -= _current_fragment.size();
+            if (_size) {
+                if (auto p = std::get_if<mb>(&_content)) {
+                    _current_fragment = managed_bytes_view::get_next_fragment(*p);
+                } else {
+                    _current_fragment = fragmented_temporary_buffer::view::get_next_fragment(std::get<ftbv>(_content));
+                }
+                _current_fragment = _current_fragment.substr(0, _size);
+            } else {
+                _current_fragment = fragment_type();
+            }
+        }
+        view prefix(size_t len) const {
+            view v = *this;
+            v._size = len;
+            v._current_fragment = v._current_fragment.substr(0, len);
+            return v;
+        }
+        friend class raw_value_view;
+    };
+private:
+    // Temporary storage is only useful if a raw_value_view needs to be instantiated
+    // with a value which lifetime is bounded only to the view itself.
+    // This hack is introduced in order to avoid storing temporary storage
+    // in an external container, which may cause memory leaking problems.
+    // This pointer is disengaged for regular raw_value_view instances.
+    // Data is stored in a shared pointer for two reasons:
+    // - pointers are cheap to copy
+    // - it makes the view keep its semantics - it's safe to copy a view multiple times
+    //   and all copies still refer to the same underlying data.
+    lw_shared_ptr<raw_value> _temporary_storage = nullptr;
+    view _view;
+
+    // This constructor is only used by make_temporary() and it acquires ownership
+    // of the given buffer. The view created that way refers to its own temporary storage.
+    explicit raw_value_view(raw_value&& temporary_storage);
+
+public:
+    raw_value_view(view data) : _view(data) {}
+    static raw_value_view make_null() {
+        return raw_value_view(view(null_value()));
+    }
+    static raw_value_view make_unset_value() {
+        return raw_value_view(view(unset_value()));
+    }
+    static raw_value_view make_value(const fragmented_temporary_buffer::view& v) {
+        return raw_value_view(view(v));
+    }
+    static raw_value_view make_value(const managed_bytes_view& v) {
+        return raw_value_view(view(v));
+    }
+    static raw_value_view make_temporary(raw_value&& value) {
+        return raw_value_view(std::move(value));
+    }
+    bool is_null() const {
+        return std::holds_alternative<null_value>(_view._content);
+    }
+    bool is_unset_value() const {
+        return std::holds_alternative<unset_value>(_view._content);
+    }
+    bool is_value() const {
+        return std::holds_alternative<view::mb>(_view._content)
+            || std::holds_alternative<view::ftbv>(_view._content);
+    }
+    explicit operator bool() const {
+        return is_value();
+    }
+    const view* operator->() const {
+        return &_view;
+    }
+    const view& operator*() const {
+        return _view;
+    }
+
+    bool operator==(const raw_value_view& other) const {
+        if (is_value() == other.is_value()) {
+            return equal_unsigned(_view, other._view);
+        } else {
+            return is_null() == other.is_null();
+        }
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const raw_value_view& value);
+    static view extract_view(const raw_value& v);
+};
+
+}
+
+inline bytes to_bytes(const cql3::raw_value& v)
+{
+    return v.to_bytes();
 }
 
 inline bytes to_bytes(const cql3::raw_value_view& view)
@@ -200,9 +273,8 @@ inline bytes to_bytes(const cql3::raw_value_view& view)
 }
 
 inline bytes_opt to_bytes_opt(const cql3::raw_value_view& view) {
-    auto buffer_view = view.data();
-    if (buffer_view) {
-        return bytes_opt(linearized(*buffer_view));
+    if (view.is_value()) {
+        return bytes_opt(linearized(*view));
     }
     return bytes_opt();
 }

--- a/types.cc
+++ b/types.cc
@@ -1609,6 +1609,7 @@ void abstract_type::validate(const View& view, cql_serialization_format sf) cons
 template void abstract_type::validate<>(const single_fragmented_view&, cql_serialization_format) const;
 template void abstract_type::validate<>(const fragmented_temporary_buffer::view&, cql_serialization_format) const;
 template void abstract_type::validate<>(const managed_bytes_view&, cql_serialization_format) const;
+template void abstract_type::validate<>(const cql3::raw_value_view::view&, cql_serialization_format) const;
 
 void abstract_type::validate(bytes_view v, cql_serialization_format sf) const {
     visit(*this, validate_visitor<single_fragmented_view>{single_fragmented_view(v), sf});
@@ -1853,6 +1854,7 @@ template data_value collection_type_impl::deserialize_impl<>(ser::buffer_view<by
 template data_value collection_type_impl::deserialize_impl<>(fragmented_temporary_buffer::view, cql_serialization_format) const;
 template data_value collection_type_impl::deserialize_impl<>(single_fragmented_view, cql_serialization_format) const;
 template data_value collection_type_impl::deserialize_impl<>(managed_bytes_view, cql_serialization_format) const;
+template data_value collection_type_impl::deserialize_impl<>(cql3::raw_value_view::view, cql_serialization_format) const;
 
 template <FragmentedView View>
 data_value deserialize_aux(const tuple_type_impl& t, View v) {
@@ -2048,6 +2050,7 @@ template data_value abstract_type::deserialize_impl<>(fragmented_temporary_buffe
 template data_value abstract_type::deserialize_impl<>(single_fragmented_view) const;
 template data_value abstract_type::deserialize_impl<>(ser::buffer_view<bytes_ostream::fragment_iterator>) const;
 template data_value abstract_type::deserialize_impl<>(managed_bytes_view) const;
+template data_value abstract_type::deserialize_impl<>(cql3::raw_value_view::view) const;
 
 int32_t compare_aux(const tuple_type_impl& t, bytes_view v1, bytes_view v2) {
     // This is a slight modification of lexicographical_tri_compare:

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -194,7 +194,7 @@ struct fragment_range {
         View _view;
         value_type _current;
     public:
-        fragment_iterator() : _view(value_type()) {}
+        fragment_iterator() = default;
         fragment_iterator(const View& v) : _view(v) {
             _current = _view.current_fragment();
         }
@@ -251,6 +251,7 @@ public:
 private:
     fragment_type _view;
 public:
+    basic_single_fragmented_view() = default;
     explicit basic_single_fragmented_view(fragment_type bv) : _view(bv) {}
     size_t size_bytes() const { return _view.size(); }
     bool empty() const { return _view.empty(); }


### PR DESCRIPTION
As a part of the effort of removing big, contiguous buffers from the codebase,
cql3::raw_value should be made fragmented. Unfortunately a straightforward
rewrite to a fragmented buffer type is not possible, because we want
cql3::raw_value to be compatible with cql3::raw_value_view, and we want that
view needs to be based on fragmented_temporary_buffer::view, so that it can be
used to view data coming directly from seastar without copying.

This patch makes cql3::raw_value fragmented by making cql3::raw_value_view
a variant of managed_bytes_view and fragmented_temporary_buffer::view.

Instead of treating those two view types as black boxes, we extract
their common parts (the first fragment and the size), which are most frequently
used, and store them directly in the raw_value_view. This way, we only need to
dispatch a call to the underlying view type when we are crossing a fragment boundary,
which is rare.